### PR TITLE
Margin v1

### DIFF
--- a/gui/gui/div.hpp
+++ b/gui/gui/div.hpp
@@ -46,6 +46,9 @@ namespace NewArch {
         simd_float4 borderColor;
         float padding;
         std::optional<float> paddingLeft, paddingRight, paddingTop, paddingBottom;
+        float margin;
+        std::optional<float> marginLeft, marginRight, marginTop, marginBottom;
+
         float top, left;
 
         Display display;
@@ -254,6 +257,16 @@ namespace NewArch {
             if (desc.paddingBottom.has_value()) li.paddingBottom = *desc.paddingBottom;
             if (desc.paddingLeft.has_value()) li.paddingLeft = *desc.paddingLeft;
 
+            
+            li.marginTop = desc.margin;
+            li.marginRight = desc.margin;
+            li.marginBottom = desc.margin;
+            li.marginLeft = desc.margin;
+            
+            if (desc.marginTop.has_value()) li.marginTop = *desc.marginTop;
+            if (desc.marginRight.has_value()) li.marginRight = *desc.marginRight;
+            if (desc.marginBottom.has_value()) li.marginBottom = *desc.marginBottom;
+            if (desc.marginLeft.has_value()) li.marginLeft = *desc.marginLeft;
 
             auto lr = ctx.layoutEngine.resolve(constraints, li, atomized);
 

--- a/gui/gui/element.cpp
+++ b/gui/gui/element.cpp
@@ -1,5 +1,5 @@
 #include "element.hpp"
-#include "gui/new_arch.hpp"
+#include "new_arch.hpp"
 #include "printers.hpp"
 #include <print>
 #include <simd/vector_types.h>
@@ -148,6 +148,7 @@ namespace NewArch {
 
             if (!childLayout.outOfFlow) {
                 childConstraints.cursor = childLayout.siblingCursor;
+                childConstraints.edgeIntent = childLayout.edgeIntent;
             }
         }
     }

--- a/gui/gui/element.cpp
+++ b/gui/gui/element.cpp
@@ -1,4 +1,5 @@
 #include "element.hpp"
+#include "gui/new_arch.hpp"
 #include "printers.hpp"
 #include <print>
 #include <simd/vector_types.h>
@@ -127,18 +128,19 @@ namespace NewArch {
             
         auto& measured = *node->measured;
         auto& atomized = *node->atomized;
-
+        
         auto layout = node->element->layout(constraints, measured, atomized);
         node->layout = layout;
 
         auto childConstraints =  layout.childConstraints;
 
-        childConstraints.origin = constraints.origin; // add static check later
+        // childConstraints.origin = constraints.origin; // add static check later
 
         // start with prev = parent
         // increasingly change prev as we see in flow elements
         // generate margin negoatiations function
 
+        // std::println("in layoutPhase: layout.childConstraints.origin.x: {}", (float)layout.childConstraints.origin.x);
         for (auto& child : node->children) {
             auto childAsPtr = child.get();
             layoutPhase(childAsPtr, frameInfo, childConstraints);

--- a/gui/gui/element.cpp
+++ b/gui/gui/element.cpp
@@ -135,6 +135,10 @@ namespace NewArch {
 
         childConstraints.origin = constraints.origin; // add static check later
 
+        // start with prev = parent
+        // increasingly change prev as we see in flow elements
+        // generate margin negoatiations function
+
         for (auto& child : node->children) {
             auto childAsPtr = child.get();
             layoutPhase(childAsPtr, frameInfo, childConstraints);

--- a/gui/gui/element.cpp
+++ b/gui/gui/element.cpp
@@ -145,7 +145,7 @@ namespace NewArch {
             auto childLayout = *childAsPtr->layout;
 
             if (!childLayout.outOfFlow) {
-                childConstraints.origin = childLayout.siblingCursor;
+                childConstraints.cursor = childLayout.siblingCursor;
             }
         }
     }

--- a/gui/gui/element.hpp
+++ b/gui/gui/element.hpp
@@ -277,6 +277,8 @@ namespace NewArch {
         */
 
         void layoutPhase(TreeNode* node, const FrameInfo& frameInfo, Constraints& constraints);
+
+
         void placePhase(TreeNode* node, const FrameInfo& frameInfo, Constraints& constraints);
         void finalizePhase(TreeNode* node, Constraints& constraints);
     };

--- a/gui/gui/element.hpp
+++ b/gui/gui/element.hpp
@@ -217,6 +217,38 @@ namespace NewArch {
         
         void measurePhase(TreeNode* node, Constraints& constraints);
         void atomizePhase(TreeNode* node, Constraints& constraints);
+
+        /*
+        Margin System Overview:
+
+        Vertical margins are represented as edges (margin-bottom of previous ↔ margin-top of current). 
+        Only in-flow elements emit vertical flow participants and participate in vertical margin negotiation. 
+
+        Out-of-flow elements (Position::Absolute or Fixed) do not participate in vertical margin negotiation 
+        with in-flow siblings, but their own margins are applied relative to their nearest positioned ancestor. 
+        If an out-of-flow element creates a boundary, it prevents margin collapse between adjacent in-flow elements.
+
+        layoutInlineNormalFlow:
+        - Horizontal margins are applied locally to the cursor.
+        - Vertical margins are aggregated into line boxes, which emit a single vertical edge for negotiation.
+
+        layoutBlockNormalFlow:
+        - Produces vertical margin intents for the block participant.
+        - Does not negotiate edges.
+
+        layoutPhase:
+        - Resolves vertical margin edges between flow participants.
+        - Applies collapse, isolation, or suppression rules.
+        - Out-of-flow boundaries break adjacency chains but do not themselves participate in collapse.
+
+        resolve / resolveNormalFlow:
+        - Produces margin intents (start/end) for a single element.
+        - Does not perform edge negotiation; vertical margins are consumed by layoutPhase.
+
+        This model ensures deterministic vertical margin behavior, proper aggregation of inline vertical margins via line boxes, 
+        and correct handling of margins for absolute/fixed elements without affecting in-flow margin negotiation.
+        */
+
         void layoutPhase(TreeNode* node, const FrameInfo& frameInfo, Constraints& constraints);
         void placePhase(TreeNode* node, const FrameInfo& frameInfo, Constraints& constraints);
         void finalizePhase(TreeNode* node, Constraints& constraints);

--- a/gui/gui/fragment_types.hpp
+++ b/gui/gui/fragment_types.hpp
@@ -27,7 +27,8 @@ struct Atom {
         length{0},
         width{0},
         height{0},
-        placeOnNewLine{false}
+        placeOnNewLine{false},
+        canPlaceOnNewLine{false}
     {}
 
     BufferHandle atomBufferHandle; // local position buffer
@@ -37,6 +38,7 @@ struct Atom {
     float width;
     float height;
 
+    bool canPlaceOnNewLine;
     bool placeOnNewLine;
 };
 

--- a/gui/gui/index.cpp
+++ b/gui/gui/index.cpp
@@ -26,7 +26,7 @@ auto index() -> void {
     (
          div(NewArch::Size::percent(0.2), NewArch::Size::percent(1.0), simd_float4{1.0,0.5,1.0,0.8})(
             div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
-                // .position(NewArch::Absolute).left(20)
+                // .position(NewArch::Absolute)
                 // .top(30)
                 .marginTop(30)
                 .marginBottom(20)

--- a/gui/gui/index.cpp
+++ b/gui/gui/index.cpp
@@ -26,8 +26,11 @@ auto index() -> void {
     (
          div(NewArch::Size::percent(0.2), NewArch::Size::percent(1.0), simd_float4{1.0,0.5,1.0,0.8})(
             div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
-                .position(NewArch::Absolute).left(20)
-                .top(30)
+                // .position(NewArch::Absolute).left(20)
+                // .top(30)
+                .marginTop(30)
+                .marginBottom(20)
+                .marginLeft(20)
                 .cornerRadius(7.5)
                 .paddingLeft(9.0)
                 .paddingTop(4.5)
@@ -38,10 +41,10 @@ auto index() -> void {
                 text("Start")
                     .fontSize(16.0)
                     .font(ArialBold)
-                // ,text("Hello world")
-                //     .fontSize(16.0)
-                //     .font(ArialBold)
-            )
+            ),
+            div(
+                NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.5,0.0,0.0,1.0}
+            ).marginTop(10)
          )
     );
 }

--- a/gui/gui/index.cpp
+++ b/gui/gui/index.cpp
@@ -25,21 +25,23 @@ auto index() -> void {
         .borderWidth(1.0)
     (
          div(NewArch::Size::percent(0.2), NewArch::Size::percent(1.0), simd_float4{1.0,0.5,1.0,0.8})(
-            div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
-                .position(NewArch::Absolute).left(20)
-                .top(30)
-                .cornerRadius(7.5)
-                .paddingLeft(9.5)
-                .paddingTop(4.5)
-                .borderColor(simd_float4{0.77,0.71,1.0,1.0})
-                .borderWidth(1.0)
-                .addEventListener(EventType::MouseDown, onClick)
-            (
+            // div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
+            //     .position(NewArch::Absolute).left(20)
+            //     .top(30)
+            //     .cornerRadius(7.5)
+            //     .paddingLeft(9.5)
+            //     .paddingTop(4.5)
+            //     .borderColor(simd_float4{0.77,0.71,1.0,1.0})
+            //     .borderWidth(1.0)
+            //     .addEventListener(EventType::MouseDown, onClick)
+            // (
                 text("Start")
                     .fontSize(18.0)
+                    .font(ArialBold),
+                text("hello world!!!!")
+                    .fontSize(18.0)
                     .font(ArialBold)
-            ),
-            div(NewArch::Size::percent(0.5), NewArch::Size::percent(1.0), simd_float4{0.0,1.0,1.0,0.8})
+            // )
          )
     );
 }

--- a/gui/gui/index.cpp
+++ b/gui/gui/index.cpp
@@ -38,7 +38,13 @@ auto index() -> void {
                 .borderWidth(1.0)
                 .addEventListener(EventType::MouseDown, onClick)
             (
-                text("Start")
+                text("Startfsd")
+                    .fontSize(16.0)
+                    .font(ArialBold)
+                    .marginLeft(10)
+                    .marginRight(10),
+
+                    text("fsdfsdf")
                     .fontSize(16.0)
                     .font(ArialBold)
             ),

--- a/gui/gui/index.cpp
+++ b/gui/gui/index.cpp
@@ -25,23 +25,23 @@ auto index() -> void {
         .borderWidth(1.0)
     (
          div(NewArch::Size::percent(0.2), NewArch::Size::percent(1.0), simd_float4{1.0,0.5,1.0,0.8})(
-            // div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
-            //     .position(NewArch::Absolute).left(20)
-            //     .top(30)
-            //     .cornerRadius(7.5)
-            //     .paddingLeft(9.5)
-            //     .paddingTop(4.5)
-            //     .borderColor(simd_float4{0.77,0.71,1.0,1.0})
-            //     .borderWidth(1.0)
-            //     .addEventListener(EventType::MouseDown, onClick)
-            // (
+            div(NewArch::Size::px(60), NewArch::Size::px(30), simd_float4{0.498,0.0,1.0,1.0})
+                .position(NewArch::Absolute).left(20)
+                .top(30)
+                .cornerRadius(7.5)
+                .paddingLeft(9.0)
+                .paddingTop(4.5)
+                .borderColor(simd_float4{0.77,0.71,1.0,1.0})
+                .borderWidth(1.0)
+                .addEventListener(EventType::MouseDown, onClick)
+            (
                 text("Start")
-                    .fontSize(18.0)
-                    .font(ArialBold),
-                text("hello world!!!!")
-                    .fontSize(18.0)
+                    .fontSize(16.0)
                     .font(ArialBold)
-            // )
+                // ,text("Hello world")
+                //     .fontSize(16.0)
+                //     .font(ArialBold)
+            )
          )
     );
 }

--- a/gui/gui/new_arch.cpp
+++ b/gui/gui/new_arch.cpp
@@ -90,13 +90,17 @@ namespace NewArch {
         lr.siblingCursor = currentCursor;
         lr.consumedHeight = 0;
 
+        // std::println("resolvedWidth: {}", resolvedWidth - layoutInput.paddingLeft - layoutInput.paddingRight);
+
         lr.childConstraints = {
-            .origin = absolutePosition,
+            .origin = {absolutePosition.x + layoutInput.paddingLeft, absolutePosition.y + layoutInput.paddingTop},
             .cursor = {absolutePosition.x + layoutInput.paddingLeft, absolutePosition.y + layoutInput.paddingTop},
             .maxWidth = resolvedWidth - layoutInput.paddingLeft - layoutInput.paddingRight,
             .maxHeight = resolvedHeight - layoutInput.paddingTop - layoutInput.paddingBottom,
             .frameInfo = constraints.frameInfo
         };
+
+        // std::println("lr.childConstraints.origin.x: {} lr.childConstraints.origin.y: {}", (float)lr.childConstraints.origin.x, (float)lr.childConstraints.origin.y);
 
         lr.computedBox = {
             .x = absolutePosition.x,
@@ -195,9 +199,9 @@ namespace NewArch {
         
         float resolvedWidth = 0;
         float resolvedHeight = 0;
-        childConstraints.origin = currentCursor;
         childConstraints.cursor.x += layoutInput.paddingLeft;
         childConstraints.cursor.y += layoutInput.paddingTop;
+        childConstraints.origin = childConstraints.cursor;
         childConstraints.frameInfo = constraints.frameInfo;
             
     
@@ -245,7 +249,7 @@ namespace NewArch {
         std::vector<simd_float2> atomOffsets;
         simd_float2 newCursor = currentCursor;
         
-        lr.childConstraints.origin = currentCursor;
+        lr.childConstraints.origin = currentCursor; // double check this
         float lineHeight = 0;
         float totalWidth = 0;
         float totalHeight = 0;
@@ -253,11 +257,12 @@ namespace NewArch {
         float maxX = currentCursor.x;
 
         // std::println("constraints.maxWidth: {}", constraints.maxWidth);
+        // std::println("origin.x: {}", (float)constraints.origin.x);    
         // std::println("newCursor.x: {}", (float)newCursor.x);
 
         for (auto& atom : atomized.atoms) {
 
-            std::println("constraints.maxWidth: {}", constraints.origin.x + constraints.maxWidth);
+            // std::println("constraints.maxWidth: {}", constraints.origin.x + constraints.maxWidth);
             // std::println("newCursor.x + atom.width: {}", (float)newCursor.x + atom.width);
             if ((constraints.maxWidth > 0 && newCursor.x + atom.width > constraints.origin.x + constraints.maxWidth)
                 || (newCursor.x + atom.width > constraints.frameInfo.width) || atom.placeOnNewLine) {
@@ -326,8 +331,6 @@ namespace NewArch {
     LayoutResult LayoutEngine::resolve(Constraints& constraints, LayoutInput& layoutInput, Atomized atomized)
     {
         LayoutResult lr;
-        
-       simd_float2 cursor = constraints.cursor;
         
         if (layoutInput.position == Position::Fixed || layoutInput.position == Position::Absolute) {
             lr = resolveOutOfFlow(constraints, constraints.cursor, layoutInput, atomized);

--- a/gui/gui/new_arch.cpp
+++ b/gui/gui/new_arch.cpp
@@ -197,12 +197,14 @@ namespace NewArch {
         float startingX = constraints.origin.x;
         float startingY = constraints.cursor.y;
         
-        if (constraints.edgeIntent.collapsable) {
-            startingY += std::max(constraints.edgeIntent.intent, layoutInput.marginTop);
-        }else {
-            startingY += constraints.edgeIntent.intent + layoutInput.marginTop;
+        if (constraints.edgeIntent.edgeDisplayMode == Display::Block) {
+            if (constraints.edgeIntent.collapsable) {
+                startingY += std::max(constraints.edgeIntent.intent, layoutInput.marginTop);
+            }else {
+                startingY += constraints.edgeIntent.intent + layoutInput.marginTop;
+            }
         }
-
+        
         startingX += layoutInput.marginLeft;
 
 
@@ -249,6 +251,7 @@ namespace NewArch {
         lr.siblingCursor = newCursor;
 
         lr.edgeIntent = {
+            .edgeDisplayMode = Display::Block,
             .intent = layoutInput.marginBottom,
             .collapsable = true,
         };

--- a/gui/gui/new_arch.cpp
+++ b/gui/gui/new_arch.cpp
@@ -69,9 +69,8 @@ namespace NewArch {
 
         simd_float2 absolutePosition = constraints.origin;
 
-
-        absolutePosition.x += layoutInput.left;
-        absolutePosition.y += layoutInput.top;
+        absolutePosition.x += layoutInput.left + layoutInput.marginLeft; // add rules for bottom/right later. They are effecitvely useless unless you use bot-0 right-0, which I havent implemented yet
+        absolutePosition.y += layoutInput.top + layoutInput.marginTop;
 
         simd_float2 newCursor = absolutePosition;
 
@@ -136,8 +135,8 @@ namespace NewArch {
         simd_float2 fixedPosition = viewportOrigin;
     
 
-        fixedPosition.x += layoutInput.left;
-        fixedPosition.y += layoutInput.top;
+        fixedPosition.x += layoutInput.left + layoutInput.marginLeft;
+        fixedPosition.y += layoutInput.top + layoutInput.marginTop;
         
         simd_float2 newCursor = fixedPosition;
         float resolvedHeight = 0.0f;

--- a/gui/gui/new_arch.cpp
+++ b/gui/gui/new_arch.cpp
@@ -252,12 +252,17 @@ namespace NewArch {
         float minX = currentCursor.x;
         float maxX = currentCursor.x;
 
+        // std::println("constraints.maxWidth: {}", constraints.maxWidth);
+        // std::println("newCursor.x: {}", (float)newCursor.x);
+
         for (auto& atom : atomized.atoms) {
 
-            if ((constraints.maxWidth > 0 && newCursor.x + atom.width > constraints.cursor.x + constraints.maxWidth)
+            std::println("constraints.maxWidth: {}", constraints.origin.x + constraints.maxWidth);
+            // std::println("newCursor.x + atom.width: {}", (float)newCursor.x + atom.width);
+            if ((constraints.maxWidth > 0 && newCursor.x + atom.width > constraints.origin.x + constraints.maxWidth)
                 || (newCursor.x + atom.width > constraints.frameInfo.width) || atom.placeOnNewLine) {
                 
-                newCursor.x = constraints.cursor.x;
+                newCursor.x = constraints.origin.x;
                 newCursor.y += lineHeight;
                 totalHeight += lineHeight;
                 lineHeight = 0;
@@ -289,12 +294,19 @@ namespace NewArch {
         
         lr.atomOffsets = atomOffsets;
         lr.consumedHeight = totalHeight;
+
+
+        // std::println("cursor x after traversal: {}", (float)newCursor.x);
         
-        if (newCursor.x >= constraints.cursor.x + constraints.maxWidth) {
-            lr.siblingCursor = {constraints.cursor.x, newCursor.y + lineHeight};
+        if (newCursor.x >= constraints.origin.x + constraints.maxWidth) {
+            lr.siblingCursor = {constraints.origin.x, newCursor.y + lineHeight};
         } else {
             lr.siblingCursor = {newCursor.x, newCursor.y};
         }
+
+        // c1x = lr.siblingCursor.x;
+        // c2x = lr.siblingCursor.y;
+        // std::println("sibling cursor x: {} sibling cursor y: {}", c1x,c2x);
         
         return lr;
     }
@@ -316,15 +328,6 @@ namespace NewArch {
         LayoutResult lr;
         
        simd_float2 cursor = constraints.cursor;
-       
-    //    for (auto i = 0; i < atomized.atoms.size(); ++i) {
-    //        auto& curr_atom = atomized.atoms[i];
-
-    //        atomOffsets.push_back(cursor);
-    //        cursor.x += curr_atom.width;
-    //    }
-    
-
         
         if (layoutInput.position == Position::Fixed || layoutInput.position == Position::Absolute) {
             lr = resolveOutOfFlow(constraints, constraints.cursor, layoutInput, atomized);

--- a/gui/gui/new_arch.hpp
+++ b/gui/gui/new_arch.hpp
@@ -160,7 +160,19 @@ namespace NewArch {
 
     
 
+    enum Position {
+        Absolute,
+        Fixed,
+        Relative,
+    };
+
+    enum Display {
+        Block,
+        Inline
+    };
+
     struct EdgeIntent {
+        Display edgeDisplayMode{Display::Block};
         float intent{};
         bool collapsable {};
     };
@@ -175,17 +187,6 @@ namespace NewArch {
 
         EdgeIntent edgeIntent{};
         // TODO: include padding details (in form of available width/height)
-    };
-
-    enum Position {
-        Absolute,
-        Fixed,
-        Relative,
-    };
-
-    enum Display {
-        Block,
-        Inline
     };
 
     struct LayoutInput {

--- a/gui/gui/new_arch.hpp
+++ b/gui/gui/new_arch.hpp
@@ -160,7 +160,7 @@ namespace NewArch {
 
     
 
-    struct InFlowEdgeIntent {
+    struct EdgeIntent {
         float intent{};
         bool collapsable {};
     };
@@ -173,7 +173,7 @@ namespace NewArch {
     
         FrameInfo frameInfo{}; // viewport size (for fixed)
 
-        InFlowEdgeIntent inflowEdgeIntent{};
+        EdgeIntent edgeIntent{};
         // TODO: include padding details (in form of available width/height)
     };
 
@@ -196,7 +196,7 @@ namespace NewArch {
         
         float width, height; // width and height of total box?
         float top, left, bottom, right; // for absolute positioning
-        float margin;
+        float margin, marginLeft, marginRight, marginTop, marginBottom;
         float padding, paddingLeft, paddingRight, paddingTop, paddingBottom;
     };
 
@@ -223,6 +223,7 @@ namespace NewArch {
     
         simd_float2 siblingCursor;
         bool outOfFlow; // don't change siblings
+        EdgeIntent edgeIntent;
     };
     
     struct LayoutEngine {

--- a/gui/gui/new_arch.hpp
+++ b/gui/gui/new_arch.hpp
@@ -50,6 +50,7 @@ namespace NewArch {
         U uniforms;
     };
 
+
     /* layout stuff */
     // --------------------------- Layout / positioning constraints ---------------------------
     //
@@ -156,6 +157,8 @@ namespace NewArch {
     //
     // ------------------------------------------------------------------------------------------
 
+
+    
 
     struct Constraints {
 

--- a/gui/gui/new_arch.hpp
+++ b/gui/gui/new_arch.hpp
@@ -160,15 +160,20 @@ namespace NewArch {
 
     
 
-    struct Constraints {
+    struct InFlowEdgeIntent {
+        float intent{};
+        bool collapsable {};
+    };
 
+    struct Constraints {
         simd_float2 origin{};
         simd_float2 cursor{};
         float maxWidth{};
         float maxHeight{};
     
         FrameInfo frameInfo{}; // viewport size (for fixed)
-        
+
+        InFlowEdgeIntent inflowEdgeIntent{};
         // TODO: include padding details (in form of available width/height)
     };
 

--- a/gui/gui/node_builder.hpp
+++ b/gui/gui/node_builder.hpp
@@ -76,6 +76,7 @@ namespace NewArch {
 
             root->attach_child(std::move(n));
         }
+
         
         
         static void reparent(TreeNode* newParent, TreeNode* child) {

--- a/gui/gui/node_builder.hpp
+++ b/gui/gui/node_builder.hpp
@@ -54,6 +54,16 @@ namespace NewArch {
         { t.paddingLeft } -> std::same_as<std::optional<float>&>;
     };
 
+    template <typename T>
+    concept HasMargin = requires(T& t) { 
+        { t.margin } -> std::convertible_to<float>;
+        { t.marginTop } -> std::same_as<std::optional<float>&>;
+        { t.marginRight } -> std::same_as<std::optional<float>&>;
+        { t.marginBottom } -> std::same_as<std::optional<float>&>;
+        { t.marginLeft } -> std::same_as<std::optional<float>&>;
+    };
+
+
     template <ElementType E, typename P>
         requires ProcessorType<P, typename E::StorageType, typename E::DescriptorType, typename E::UniformsType>
     struct NodeBuilder {
@@ -220,6 +230,49 @@ namespace NewArch {
             desc.paddingLeft = padding;
             return *this;
         }
+
+        // margin
+
+        NodeBuilder<E,P>& margin(float margin) requires HasMargin<typename E::DescriptorType> {
+            auto* elem = static_cast<ElemT*>(node->element.get());
+            auto& rawElem = elem->element;
+            auto& desc = rawElem.getDescriptor();
+            desc.margin = margin;
+            return *this;
+        }
+
+        NodeBuilder<E,P>& marginTop(float margin) requires HasMargin<typename E::DescriptorType> {
+            auto* elem = static_cast<ElemT*>(node->element.get());
+            auto& rawElem = elem->element;
+            auto& desc = rawElem.getDescriptor();
+            desc.marginTop = margin;
+            return *this;
+        }
+
+        NodeBuilder<E,P>& marginRight(float margin) requires HasMargin<typename E::DescriptorType> {
+            auto* elem = static_cast<ElemT*>(node->element.get());
+            auto& rawElem = elem->element;
+            auto& desc = rawElem.getDescriptor();
+            desc.marginRight = margin;
+            return *this;
+        }
+
+        NodeBuilder<E,P>& marginBottom(float margin) requires HasMargin<typename E::DescriptorType> {
+            auto* elem = static_cast<ElemT*>(node->element.get());
+            auto& rawElem = elem->element;
+            auto& desc = rawElem.getDescriptor();
+            desc.marginBottom = margin;
+            return *this;
+        }
+
+        NodeBuilder<E,P>& marginLeft(float margin) requires HasMargin<typename E::DescriptorType> {
+            auto* elem = static_cast<ElemT*>(node->element.get());
+            auto& rawElem = elem->element;
+            auto& desc = rawElem.getDescriptor();
+            desc.marginLeft = margin;
+            return *this;
+        }
+        
 
         using NodeBuilderEventHandler = std::function<void(typename E::DescriptorType& descriptor, const Event& event)>;
 

--- a/gui/gui/text.hpp
+++ b/gui/gui/text.hpp
@@ -43,6 +43,9 @@ namespace NewArch {
         
         Display display;
         Position position;
+
+        float margin;
+        std::optional<float> marginLeft, marginRight, marginTop, marginBottom;
     };
 
 
@@ -222,6 +225,8 @@ namespace NewArch {
                     
                     atoms.push_back(atom);
                     continue;
+                }else if (ch == ' '){
+                    atom.canPlaceOnNewLine = true;
                 }
 
 
@@ -296,6 +301,16 @@ namespace NewArch {
             LayoutInput li;
             li.display = desc.display;
             li.position = desc.position;
+
+            li.marginTop = desc.margin;
+            li.marginRight = desc.margin;
+            li.marginBottom = desc.margin;
+            li.marginLeft = desc.margin;
+            
+            if (desc.marginTop.has_value()) li.marginTop = *desc.marginTop;
+            if (desc.marginRight.has_value()) li.marginRight = *desc.marginRight;
+            if (desc.marginBottom.has_value()) li.marginBottom = *desc.marginBottom;
+            if (desc.marginLeft.has_value()) li.marginLeft = *desc.marginLeft;
 
             auto lr = ctx.layoutEngine.resolve(constraints, li, atomized);
 


### PR DESCRIPTION
Added basic rules for margin for out of flow and in flow elements (fixed, absolute, inline and block considered). 

Areas of difference with browsers that need to be resolved in Margin v2:
- bottom/right handling along with marginBottom/marginRight. These are currently useless (most use cases in html/css never see this) but will become important if bottom and right are set. However, if top and left are also set, then there are a specific set of rules that need to be considered
- Text wrapping: html/css has a significantly less sophisticated algorithm for line breaking, which just tests if theres a space. The key difference is that it seems to precompute line boxes BEFORE placing them, and greedily placing them either at the origin or right after the previous line box